### PR TITLE
FIX/lib/StupidArtnet.py: ensure BUFFER length equals PACKET_SIZE

### DIFF
--- a/lib/StupidArtnet.py
+++ b/lib/StupidArtnet.py
@@ -29,7 +29,7 @@ class StupidArtnet():
 		self.NET = 0
 		self.PACKET_SIZE = self.put_in_range(packet_size, 2, 512)
 		self.HEADER = bytearray()
-		self.BUFFER = bytearray(packet_size)
+		self.BUFFER = bytearray(self.PACKET_SIZE)
 
 		self.bIsSimplified = True		# simplify use of universe, net and subnet
 


### PR DESCRIPTION
When constructing a StupidArtnet instance the `self.BUFFER` is setup using the
argument `packet_size` instead of the `self.PACKET_SIZE` property, which could
lead to mismatch of the buffers length and the requested packet size. This happened
because `self.PACKET_SIZE` is initialized using the `put_in_range` function,
which is using the `make_even` argument set to True by default. Passing an
uneven packet size to the constructor therefore leads to mistches, e.g.:

```python
led_count = 9
artnet = StupidArtnet("127.0.0.1", 0, led_count * 3, 24)
```

The fix was easy by initializing `BUFFER` using the `PACKET_SIZE` property
instead of the passed arugment

Cheers and thanks for the library in the first place